### PR TITLE
examples: Update single container sleep time

### DIFF
--- a/single-service-app/Dockerfile.template
+++ b/single-service-app/Dockerfile.template
@@ -1,3 +1,3 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:stretch
 
-CMD ["/bin/bash", "-c", "date >> /data/datestamps; sleep infinity"]
+CMD ["/bin/bash", "-c", "echo 'Single Service Application'; sleep 5"]


### PR DESCRIPTION
When following the guide with the current example, there is no restarting in the logs as `sleep infinity` is already present.

Change-type: patch
Signed-off-by: Gareth Davies gareth@balena.io