### PR TITLE
Improve systemd balena push command

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,7 @@ We're now ready to push the multicontainer application for running `systemd` to
 your application:
 
 ```shell
+$ cd $BALENA_SERVICES_MASTERCLASS/systemd
 $ balena push systemd
 balena push systemd --nocache
 [Info]     Starting build for systemd, user heds
@@ -987,7 +988,7 @@ a running, non-exiting `systemd`-based service container.
 
 There is a problem with how we're running our container, though. Have a look at
 the definition of the `printer` service for the
-`$BALENA_SERVICES_MASTERCLASS/systemd/printer/docker-compose.yml` file:
+`$BALENA_SERVICES_MASTERCLASS/systemd/docker-compose.yml` file:
 
 ```yaml
   printer:


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

While going through the docs I accidentally `balena push`ed a single service app as I was currently in `systemd/printer` and not in `systemd`. Should make this a bit clearer as it was confusing when the next step told me to SSH into the `printer` service which doesn't exist if you push a single service app.

Also fix `systemd` app `docker-compose.yml` path.