### PR TITLE
update containers base images

### DIFF
--- a/multi-stage/Dockerfile.template
+++ b/multi-stage/Dockerfile.template
@@ -1,7 +1,10 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:buster
+FROM debian:trixie-slim
 
 # Install build essential tools to include GCC
-RUN install_packages build-essential
+RUN apt update && \
+    apt install -y  build-essential && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Compile the executable from some C source
 WORKDIR /usr/src/app

--- a/multicontainer-app/backend/Dockerfile.template
+++ b/multicontainer-app/backend/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-node:10
+FROM node:lts-trixie
 
 WORKDIR /usr/src/app
 

--- a/multicontainer-app/frontend/Dockerfile.template
+++ b/multicontainer-app/frontend/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-node:10
+FROM node:lts-trixie-slim
 
 WORKDIR /usr/src/app
 

--- a/single-service-app/Dockerfile.template
+++ b/single-service-app/Dockerfile.template
@@ -1,3 +1,3 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:stretch
+FROM debian:trixie-slim
 
 CMD ["/bin/bash", "-c", "echo 'Single Service Fleet'; sleep 5"]

--- a/systemd/printer/Dockerfile.template
+++ b/systemd/printer/Dockerfile.template
@@ -1,1 +1,25 @@
+FROM node:lts-trixie-slim
 
+# Install both DBus and systemd support
+RUN apt update && \
+    apt install -y dbus systemd && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Mask services which do not make sense to run in a service container
+RUN systemctl mask \
+    dev-hugepages.mount \
+    sys-fs-fuse-connections.mount \
+    sys-kernel-config.mount \
+    display-manager.service \
+    getty@.service \
+    systemd-logind.service \
+    systemd-remount-fs.service \
+    getty.target \
+    graphical.target
+
+RUN systemctl set-default multi-user.target
+
+COPY entry.sh /usr/bin
+STOPSIGNAL 37
+ENTRYPOINT ["/usr/bin/entry.sh"]


### PR DESCRIPTION
Mostly an update to Docker images.

Note that for systemd/printer/Dockerfile.template the file is initially empty and is intended to be copied from the [master class](https://docs.balena.io/learn/more/masterclasses/services-masterclass/#5-running-systemd-in-a-service). So this update necessitate an update on the master class side too.